### PR TITLE
Fix/pr-context-path-error-#50

### DIFF
--- a/.github/agents/atomic_planning.agent.md
+++ b/.github/agents/atomic_planning.agent.md
@@ -2,7 +2,6 @@
 name: atomic_planner
 description: Generate phased implementation plans with atomic checkbox tasks that have binary completion and clear acceptance criteria.
 argument-hint: "Describe the goal or change you want a phased atomic plan for."
-target: vscode
 tools:
    ['read/readFile', 'edit/createDirectory', 'edit/createFile', 'edit/editFiles', 'search', 'web', 'agent', 'todo']
 handoffs:

--- a/docs/features/potential/promoted/2026-02-09-pr-context-path-error.md
+++ b/docs/features/potential/promoted/2026-02-09-pr-context-path-error.md
@@ -1,0 +1,88 @@
+# pr-context-path-error (Issue #50)
+
+- Date captured: 2026-02-09
+- Author: Dan Moisan
+- Status: Promoted -> docs/features/active/pr-context-path-error/ (Issue #50)
+
+> Automation note: Keep the section headings below unchanged; the promotion tooling maps each of them into the GitHub bug issue template.
+
+- Issue: #50
+- Issue URL: https://github.com/drmoisan/transcript-etl-pipeline/issues/50
+- Last Updated: 2026-02-09
+## Summary
+
+PR context collector crashes with NotADirectoryError when attempting to iterate over `README.md` file as if it were a directory in `docs/features/active/`.
+
+## Environment
+
+- OS/version: Windows 11
+- Python version: Python 3.13
+- Command/flags used: `poetry run python -m scripts.dev_tools.pr_context.collector --base origin/master`
+- Data source or fixture: docs/features/active/ directory containing both subdirectories and a README.md file
+
+## Steps to Reproduce
+
+1. Ensure `docs/features/active/README.md` exists alongside feature subdirectories
+2. Run `poetry run python -m scripts.dev_tools.pr_context.collector --base origin/master`
+3. Observe crash during feature docs gathering
+
+## Expected Behavior
+
+The PR context collector should iterate only over feature subdirectories in `docs/features/active/`, ignoring non-directory items like `README.md`, and successfully collect feature documentation excerpts.
+
+## Actual Behavior
+
+The collector crashes with `NotADirectoryError: [WinError 267] The directory name is invalid: 'C:\\Users\\DanMoisan\\source\\repos\\transcript-etl-pipeline\\docs\\features\\active\\README.md'` when `_select_latest_version_dir()` attempts to call `iterdir()` on the README.md file path.
+
+## Logs / Screenshots
+
+- [x] Attached minimal logs or screenshot
+- Snippet:
+
+```
+NotADirectoryError: [WinError 267] The directory name is invalid: 
+'C:\\Users\\DanMoisan\\source\\repos\\transcript-etl-pipeline\\docs\\features\\active\\README.md'
+
+File "C:\...\feature_docs.py", line 188, in gather_feature_excerpts
+    resolved_dir = _select_latest_version_dir(active_dir)
+File "C:\...\feature_docs.py", line 41, in _select_latest_version_dir
+    for child in sorted(base_dir.iterdir()):
+```
+
+## Impact / Severity
+
+- [x] Blocker - prevents PR context generation entirely
+- [ ] High
+- [ ] Medium
+- [ ] Low
+
+## Suspected Cause / Notes
+
+In `scripts/dev_tools/pr_context/feature_docs.py`, the `_select_latest_version_dir()` function at line 41 iterates over all children returned by `base_dir.iterdir()` without filtering out files first. When `README.md` is encountered in the sorted iteration, the code later attempts to treat it as a directory, causing the crash.
+
+The `is_dir()` check happens after sorting all items, but the error occurs because somewhere in the call chain a file path is being passed where a directory is expected.
+
+## Proposed Fix / Validation Ideas
+
+**Fix**: In `_select_latest_version_dir()` at line 41, filter to directories before sorting:
+
+```python
+# Filter out files immediately - only iterate over directories
+dirs = [child for child in base_dir.iterdir() if child.is_dir()]
+
+for child in sorted(dirs):
+    # Extract version from directory name (v1, v2, etc.)
+    match = re.match(r"^v(\d+)$", child.name)
+    if match:
+        return child
+```
+
+**Validation**:
+- [x] Unit coverage: Add test for `_select_latest_version_dir()` with mixed files/directories
+- [x] Integration scenario: Run full PR context collector with README.md present
+- [x] Manual verification: Verify feature docs are properly extracted without crash
+
+## Next Step
+
+- [ ] Promote to GitHub issue (bug-report template)
+- [ ] Move to active fix folder / branch

--- a/scripts/dev_tools/pr_context/feature_docs.py
+++ b/scripts/dev_tools/pr_context/feature_docs.py
@@ -72,6 +72,10 @@ def _feature_key_from_active_parts(parts: tuple[str, ...]) -> str | None:
     if _is_excluded_nested_child(parts[3]):
         return None
 
+    # Ignore top-level files (like README.md) under docs/features/active.
+    if len(parts) == 4 and Path(parts[3]).suffix:
+        return None
+
     # Versioned child folders are treated as part of the epic/feature scope.
     if len(parts) >= 6 and _version_number(parts[5]) is not None:
         if _is_excluded_nested_child(parts[4]):

--- a/scripts/dev_tools/pr_context/render.py
+++ b/scripts/dev_tools/pr_context/render.py
@@ -85,6 +85,10 @@ def _feature_key_from_active_parts(parts: tuple[str, ...]) -> str | None:
     if _is_excluded_nested_child(parts[3]):
         return None
 
+    # Ignore top-level files (like README.md) under docs/features/active.
+    if len(parts) == 4 and Path(parts[3]).suffix:
+        return None
+
     # Versioned child folders are treated as part of the epic/feature scope.
     if len(parts) >= 6 and _version_number(parts[5]) is not None:
         if _is_excluded_nested_child(parts[4]):

--- a/tests/dev_tools/test_feature_docs.py
+++ b/tests/dev_tools/test_feature_docs.py
@@ -97,6 +97,15 @@ class TestExtractIssueReferences:
 
 
 class TestGatherFeatureExcerpts:
+    def test_gather_feature_excerpts_ignores_active_readme(self) -> None:
+        """Ensure top-level active README.md paths are ignored safely."""
+        repo_root = Path(__file__).resolve().parents[2]
+
+        changed_files = ["docs/features/active/README.md"]
+        excerpts = gather_feature_excerpts(repo_root, changed_files)
+
+        assert excerpts == []
+
     def test_gather_feature_excerpts_direct_match(self, tmp_path: Path) -> None:
         feature_dir = tmp_path / "docs" / "features" / "active" / "test-feature"
         feature_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
Fixes path handling for PR-context feature docs so the PR context tooling can reliably locate/render feature documentation without path errors.

## User / Dev impact
- PR-context generation becomes more robust against path-resolution edge cases.
- Reduces failure cases when rendering or discovering feature docs.

## Changes
### Core logic
- `scripts/dev_tools/pr_context/feature_docs.py` (+4): adjust feature doc path handling
- `scripts/dev_tools/pr_context/render.py` (+4): render path handling adjustment
- `tests/dev_tools/test_feature_docs.py` (+9): adds coverage for the corrected behavior

### Docs / tooling
- `docs/features/potential/promoted/2026-02-09-pr-context-path-error.md` (+88): documents the bug + rationale / notes
- `.github/agents/atomic_planning.agent.md` (-1): minor adjustment

## Risks
- Low: small, localized path-handling changes.
- Primary risk: unexpected edge-case paths not covered by existing tests.

## Test evidence
- Added/updated unit tests (`tests/dev_tools/test_feature_docs.py`).
- CI status: not available in current context.

## Auto-clos
- Closes #50