### PR TITLE
(fix) incorrect branch names for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, feature/*]
+    branches: [master, development, feature/*]
   pull_request:
-    branches: [main, develop]
+    branches: [master, development]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
CI was not being triggered because of incorrect branch names. This prevented branch protection rules from being satisfied.