### PR TITLE
Sync CI commit from master to development

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, feature/*]
+    branches: [master, development, feature/*]
   pull_request:
-    branches: [main, develop]
+    branches: [master, development]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The master branch had an incorrect set of branch names for pull requests. That created a situation where branch protection prevented merge until a ci ran that would never run. This PR brings that commit to a temporary branch for merging into development